### PR TITLE
fix: materialized view pkey test

### DIFF
--- a/materialized_view_test.sql
+++ b/materialized_view_test.sql
@@ -42,8 +42,20 @@ select is_empty(
 );
 
 -- GUIDELINE: All materialized views must have a primary key
--- Get all materialized views in schema that do not have an index matching %primary%
-prepare null_pkey as select tablename from pg_indexes where not exists (select indexname from pg_indexes where indexname like '%primary%') and schemaname = any (string_to_array(:'schemas_to_test', ','));
+-- Get all materialized views in schema that do not have a unique index
+prepare null_pkey as
+  select distinct matviewname from pg_matviews
+  left join pg_indexes
+  on matviewname = tablename
+  where matviewname not in (
+  select pi.tablename
+  from pg_catalog.pg_namespace n
+  join pg_catalog.pg_class c on c.relnamespace = n.oid
+  join pg_catalog.pg_index i on i.indexrelid = c.oid
+  join pg_indexes pi on relname=indexname
+  where n.nspname = any (string_to_array(:'schemas_to_test', ','))
+  and i.indisunique=true)
+  and pg_matviews.schemaname = any (string_to_array(:'schemas_to_test', ','));
 -- Test that the above query returns nothing, else throw an error
 select is_empty('null_pkey', 'All materialized views must have a primary key');
 


### PR DESCRIPTION
The materialized view pkey test included tables and was too opinionated by looking specifically for indices that included the word 'primary'.
This PR changes the test to only look for materialized views that are missing a unique index.